### PR TITLE
fix: explicitly state port for vite commands run from within devcontainer

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host 127.0.0.1",
     "build": "vite build",
     "lint": "eslint . --report-unused-disable-directives --fix",
-    "preview": "vite preview",
+    "preview": "vite --host 127.0.0.1",
     "check": "tsc --noEmit",
     "format": "prettier . --write",
     "prepare": "husky"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite --host 127.0.0.1",
     "build": "vite build",
     "lint": "eslint . --report-unused-disable-directives --fix",
-    "preview": "vite --host 127.0.0.1",
+    "preview": "vite preview --host 127.0.0.1",
     "check": "tsc --noEmit",
     "format": "prettier . --write",
     "prepare": "husky"


### PR DESCRIPTION
# Issue
When using newer versions of docker (or devcontainers, I updated both at the same time), devcontainers do not properly forward the internal ports. The tunnel appears to exist on the host, and in the docker shell you can curl a webpage, but the connection is broken or something.
# Fix
add explicit host url to the dev and preview commands, so the url as well as the port get auto recognized.