### PR TITLE
fix: Display custom icon when temperature is undefined or query fails

### DIFF
--- a/src/components/Weather.tsx
+++ b/src/components/Weather.tsx
@@ -28,7 +28,14 @@ export default function Weather() {
     pollingInterval: 600000, // 10 * 60 * 1000, 10 minutes
   });
 
-  if (!isSuccess) return <></>;
+  if (!isSuccess || weather.liveweer[0].temp === undefined)
+    return (
+      <div className="weather-wrapper">
+        <span className="material-symbols-outlined weather-icon weather-fetch-fail">
+          cloud_alert
+        </span>
+      </div>
+    );
 
   return (
     <div className="weather-wrapper">

--- a/src/index.css
+++ b/src/index.css
@@ -65,6 +65,10 @@ body {
   font-size: 72px;
   color: #808080;
 }
+.weather-fetch-fail {
+  color: #b35d5d;
+  font-size: 72px;
+}
 
 .weather-text {
   color: white;


### PR DESCRIPTION
Does not solve #183, but provides a fallback that is more pleasant to look at.

![image](https://github.com/user-attachments/assets/2f696f7e-c997-4ac3-a8d4-ed4c3861cc05)

Fallback also displays when `isSuccess` is false (which would not display anything before).
