### PR TITLE
feat: poster transitions

### DIFF
--- a/src/components/Activities.tsx
+++ b/src/components/Activities.tsx
@@ -26,7 +26,6 @@ export default function Activities({ current }: StateMachineSlideProps) {
   }
 
   const currentActivity = activities[current];
-
   return (
     <ContentWithPoster posterSrc={currentActivity.poster}>
       <TopBar />

--- a/src/components/Activities.tsx
+++ b/src/components/Activities.tsx
@@ -26,6 +26,14 @@ export default function Activities({ current }: StateMachineSlideProps) {
   }
 
   const currentActivity = activities[current];
+
+  /* preload next poster */
+  const nextActivity = activities[current + 1];
+  if (nextActivity) {
+    const img = new Image();
+    img.src = nextActivity.poster;
+  }
+
   return (
     <ContentWithPoster posterSrc={currentActivity.poster}>
       <TopBar />

--- a/src/components/Activities.tsx
+++ b/src/components/Activities.tsx
@@ -27,13 +27,6 @@ export default function Activities({ current }: StateMachineSlideProps) {
 
   const currentActivity = activities[current];
 
-  /* preload next poster */
-  const nextActivity = activities[current + 1];
-  if (nextActivity) {
-    const img = new Image();
-    img.src = nextActivity.poster;
-  }
-
   return (
     <ContentWithPoster posterSrc={currentActivity.poster}>
       <TopBar />

--- a/src/components/ContentWithPoster.tsx
+++ b/src/components/ContentWithPoster.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react';
+import TransitionImage from './TransitionImage';
 
 type ContentWithPosterProps = {
   children: ReactNode;
@@ -12,7 +13,9 @@ export default function ContentWithPoster({
   return (
     <div className="content-with-poster">
       <div className="content-wrapper">{children}</div>
-      <img src={posterSrc} className="poster" />
+      <div className="poster">
+        <TransitionImage src={posterSrc} />
+      </div>
     </div>
   );
 }

--- a/src/components/TransitionImage.tsx
+++ b/src/components/TransitionImage.tsx
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react';
+
+type TransitionImage = {
+  src: string;
+};
+
+export default function TransitionImage({ src }: TransitionImage) {
+  const [loaded, setLoaded] = useState(false);
+  const [inTransition, setInTransition] = useState(true);
+  const [currentSrc, setCurrentSrc] = useState<string | null>(null);
+  const [prevSrc, setPrevSrc] = useState<string | null>(null);
+
+  /* update current and previous src when src changes */
+  if (currentSrc !== src) {
+    setPrevSrc(currentSrc);
+    setCurrentSrc(src);
+  }
+
+  useEffect(() => {
+    setInTransition(true);
+    const id = setTimeout(() => setInTransition(false), 1000);
+    return () => clearTimeout(id);
+  });
+
+  return (
+    <div className="transition-image">
+      <img
+        src={src}
+        key={src}
+        className={`current ${loaded ? 'loaded' : ''}`}
+        onLoad={() => setLoaded(true)}
+      />
+      {prevSrc && inTransition && (
+        <img src={prevSrc} key={prevSrc} className="previous" />
+      )}
+    </div>
+  );
+}

--- a/src/index.scss
+++ b/src/index.scss
@@ -113,6 +113,40 @@ body {
   }
 }
 
+.transition-image {
+  /* grid stacking */
+  display: grid;
+  grid-template-rows: auto;
+
+  & > .current {
+    grid-area: 1 / 1 / 2 / 2;
+    height: 100%;
+    width: 100%;
+    opacity: 0;
+
+    &.loaded {
+      animation: posterFade 500ms ease-out forwards;
+    }
+
+    @keyframes posterFade {
+      0% {
+        opacity: 0;
+        transform: translateY(50px);
+      }
+      100% {
+        opacity: 1;
+      }
+    }
+  }
+
+  & > .previous {
+    grid-area: 1 / 1 / 2 / 2;
+    height: 100%;
+    width: 100%;
+    z-index: -1;
+  }
+}
+
 .scrollable-list {
   position: relative;
   overflow: hidden;


### PR DESCRIPTION
Closes #149.

Adds a simple fade (+ slide) transition to posters in the activities and poster ads.