### PR TITLE
fix: recovery after disconnect

### DIFF
--- a/src/components/Activities.tsx
+++ b/src/components/Activities.tsx
@@ -7,9 +7,7 @@ import ContentWithPoster from './ContentWithPoster';
 export default function Activities({ current }: StateMachineSlideProps) {
   useTimer({ interval: true });
 
-  const { data: activities, isSuccess } = useActivitiesQuery(undefined, {
-    pollingInterval: Number(import.meta.env.VITE_LOAD_INTERVAL),
-  });
+  const { data: activities, isSuccess } = useActivitiesQuery(undefined);
 
   if (!isSuccess) return <></>;
   if (activities.length === 0) {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,9 +7,11 @@ import store from './store/index.js';
 
 import './index.scss';
 import './snow.scss';
+import { setupListeners } from '@reduxjs/toolkit/query';
 
 const root = document.getElementById('root');
 if (root) {
+  setupListeners(store.dispatch);
   createRoot(root).render(
     <Provider store={store}>
       <React.StrictMode>

--- a/src/store/api/contentful.ts
+++ b/src/store/api/contentful.ts
@@ -79,6 +79,9 @@ export const contentful = createApi({
       query: () => 'quotes',
     }),
   }),
+  keepUnusedDataFor: 60 * 60, // big number
+  refetchOnReconnect: true,
+  refetchOnMountOrArgChange: Number(import.meta.env.VITE_LOAD_INTERVAL),
 });
 
 export const { useAdsQuery, useBoardMessagesQuery, useQuotesQuery } =

--- a/src/store/api/github.ts
+++ b/src/store/api/github.ts
@@ -100,6 +100,9 @@ export const github = createApi({
     allCommits: build.query<Commit[], void>({ queryFn: allCommits }),
     members: build.query<Member[], void>({ queryFn: allMembers }),
   }),
+  keepUnusedDataFor: 60 * 60, // big number
+  refetchOnReconnect: true,
+  refetchOnMountOrArgChange: Number(import.meta.env.VITE_LOAD_INTERVAL),
 });
 
 export const { useAllCommitsQuery, useMembersQuery } = github;

--- a/src/store/api/koala.ts
+++ b/src/store/api/koala.ts
@@ -47,6 +47,9 @@ export const koala = createApi({
           ),
     }),
   }),
+  keepUnusedDataFor: 60 * 60, // big number
+  refetchOnReconnect: true,
+  refetchOnMountOrArgChange: Number(import.meta.env.VITE_LOAD_INTERVAL),
 });
 
 export const { useActivitiesQuery } = koala;

--- a/src/store/api/weather.ts
+++ b/src/store/api/weather.ts
@@ -31,7 +31,9 @@ export const weather = createApi({
         `weerlive_api_v2.php?key=${import.meta.env.VITE_WEATHER_API_TOKEN}&locatie=52.08718206955104,5.165697854286648`,
     }),
   }),
-  keepUnusedDataFor: 60 * 60,
+  keepUnusedDataFor: 60 * 60, // big number
+  refetchOnReconnect: true,
+  refetchOnMountOrArgChange: Number(import.meta.env.VITE_LOAD_INTERVAL),
 });
 
 export const { useWeatherQuery } = weather;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -32,10 +32,9 @@ export const nextState: ThunkAction<void, RootState, void, UnknownAction> = (
   switch (state.screen.current) {
     case StateMachineState.Activities:
       {
-        const { data: activities, isSuccess } =
-          koala.endpoints.activities.select()(state);
+        let { data: activities } = koala.endpoints.activities.select()(state);
 
-        if (!isSuccess) throw new Error('');
+        if (!activities) activities = [];
 
         if (state.screen.screenCurrentIndex >= activities.length - 1) {
           dispatch(resetCurrentIndex());


### PR DESCRIPTION
Radio can now recover from being disconnected. Multiple major changes:

- No longer using `pollingInterval` to update activities in real-time, as this is useless; The property is used to refetch while component is mounted, but activities unmounts before the first refetch even happens.
- Every api now has `keepUnusedDataFor: 60 * 60`. This keeps the cache alive at all times (since the components remount within that time), providing data to fallback to when there is no internet connection.
- Added `setupListeners` call to main.tsx to allow RTK query to respond to events like disconnect/reconnect
- Added `refetchOnReconnect: true` to every api to force refetch immediately after getting online again.
- Added `refetchOnMountOrArgChange` to every api to refetch data on mount after `VITE_LOAD_INTERVAL` seconds have passed, which is how we achieve polling rate.